### PR TITLE
Disable the default focus blue highlight on Android

### DIFF
--- a/Plugins/NativeEditBox/Android/NativeEditBox.java
+++ b/Plugins/NativeEditBox/Android/NativeEditBox.java
@@ -19,6 +19,7 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import com.unity3d.player.R;
 import com.unity3d.player.UnityPlayer;
 
 import java.util.Locale;
@@ -100,6 +101,12 @@ public class NativeEditBox {
             public void run() {
                 if(mEditBox != null)
                     return;
+            
+                // Disable defaulthighlight overlay, see https://github.com/Genymobile/scrcpy/issues/5089
+                View view = activityRootView.findViewById(R.id.unitySurfaceView);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    view.setDefaultFocusHighlightEnabled(false);
+                }
 
                 mEditBox = new EditText(activity);
 


### PR DESCRIPTION
On Android, after adding an EditText, some devices will display a blue overlay on the Unity surface view when it gains focus. This is a highlight added by the Android system by default; this behavior can be disabled via code.😊

It looks like this when a bug occurs: https://github.com/Genymobile/scrcpy/issues/5089